### PR TITLE
Added brightway25 support

### DIFF
--- a/polyviz/chord.py
+++ b/polyviz/chord.py
@@ -4,13 +4,23 @@ Modules contains functions to generate a Chord diagram.
 
 import bw2data
 from d3blocks import D3Blocks
+from typing import Union
 
 from .dataframe import format_supply_chain_dataframe
 from .utils import calculate_supply_chain, check_filepath
 
+try:
+    from bw2data.backends.peewee import Activity as PeeweeActivity
+except ImportError:
+    PeeweeActivity = None
 
+try: 
+    from bw2data.backends import Activity as BW25Activity
+except ImportError:
+    BW25Activity = None
+    
 def chord(
-    activity: bw2data.backends.peewee.proxies.Activity,
+    activity: Union[PeeweeActivity, BW25Activity],
     method: tuple = None,
     flow_type: str = None,
     level: int = 3,

--- a/polyviz/choro.py
+++ b/polyviz/choro.py
@@ -4,13 +4,23 @@ Module that contains code to produce a Choropleth diagram.
 
 import bw2data
 from d3blocks import D3Blocks
+from typing import Union
 
 from .dataframe import distribute_region_impacts
 from .utils import check_filepath, get_geo_distribution_of_impacts_for_choro_graph
 
+try:
+    from bw2data.backends.peewee import Activity as PeeweeActivity
+except ImportError:
+    PeeweeActivity = None
+
+try: 
+    from bw2data.backends import Activity as BW25Activity
+except ImportError:
+    BW25Activity = None
 
 def choro(
-    activity: bw2data.backends.peewee.proxies.Activity,
+    activity: Union[PeeweeActivity, BW25Activity],
     method: tuple,
     cutoff: float = 0.001,
     filepath: str = None,
@@ -35,7 +45,7 @@ def choro(
 
     assert isinstance(method, tuple), "`method` should be a tuple."
     assert isinstance(
-        activity, bw2data.backends.peewee.proxies.Activity
+        activity, Union[PeeweeActivity, BW25Activity]
     ), "`activity` should be a brightway2 activity."
 
     # fetch unit of method

--- a/polyviz/dataframe.py
+++ b/polyviz/dataframe.py
@@ -5,7 +5,7 @@ the recursive calculation into a pandas dataframe.
 
 from collections import defaultdict
 from io import StringIO
-from typing import List
+from typing import List, Union
 
 import bw2data
 import numpy as np
@@ -13,6 +13,15 @@ import pandas as pd
 
 from .utils import calculate_lcia_score, get_gdp_per_country, get_region_definitions
 
+try:
+    from bw2data.backends.peewee import Activity as PeeweeActivity
+except ImportError:
+    PeeweeActivity = None
+
+try: 
+    from bw2data.backends import Activity as BW25Activity
+except ImportError:
+    BW25Activity = None
 
 def format_supply_chain_dataframe(
     results: List[List], amount: int = 1, flow_type: str = None
@@ -136,7 +145,7 @@ def add_country_column(dataframe: pd.DataFrame) -> pd.DataFrame:
 
 
 def get_geo_distribution_of_impacts(
-    activity: bw2data.backends.peewee.proxies.Activity,
+    activity: Union[PeeweeActivity, BW25Activity],
     method: tuple,
     cutoff: float = 0.0001,
 ):

--- a/polyviz/force.py
+++ b/polyviz/force.py
@@ -4,13 +4,23 @@ This module contains the code to produce a force-directed graph.
 
 import bw2data
 from d3blocks import D3Blocks
+from typing import Union
 
 from .dataframe import format_supply_chain_dataframe
 from .utils import calculate_supply_chain, check_filepath
 
+try:
+    from bw2data.backends.peewee import Activity as PeeweeActivity
+except ImportError:
+    PeeweeActivity = None
+
+try: 
+    from bw2data.backends import Activity as BW25Activity
+except ImportError:
+    BW25Activity = None
 
 def force(
-    activity: bw2data.backends.peewee.proxies.Activity,
+    activity: Union[PeeweeActivity, BW25Activity],
     method: tuple,
     level: int = 3,
     cutoff: float = 0.01,

--- a/polyviz/sankey.py
+++ b/polyviz/sankey.py
@@ -4,13 +4,23 @@ This module contains the code to generate a Sankey diagram for a given activity 
 
 import bw2data
 from d3blocks import D3Blocks
+from typing import Union
 
 from .dataframe import format_supply_chain_dataframe
 from .utils import calculate_supply_chain, check_filepath
 
+try:
+    from bw2data.backends.peewee import Activity as PeeweeActivity
+except ImportError:
+    PeeweeActivity = None
+
+try: 
+    from bw2data.backends import Activity as BW25Activity
+except ImportError:
+    BW25Activity = None
 
 def sankey(
-    activity: bw2data.backends.peewee.proxies.Activity,
+    activity: Union[PeeweeActivity, BW25Activity],
     method: tuple = None,
     flow_type: str = None,
     level: int = 3,

--- a/polyviz/treemap.py
+++ b/polyviz/treemap.py
@@ -4,13 +4,23 @@ This module contains the function to generate a treemap.
 
 import bw2data
 from d3blocks import D3Blocks
+from typing import Union
 
 from .dataframe import get_geo_distribution_of_impacts
 from .utils import check_filepath
 
+try:
+    from bw2data.backends.peewee import Activity as PeeweeActivity
+except ImportError:
+    PeeweeActivity = None
+
+try: 
+    from bw2data.backends import Activity as BW25Activity
+except ImportError:
+    BW25Activity = None
 
 def treemap(
-    activity: bw2data.backends.peewee.proxies.Activity,
+    activity: Union[PeeweeActivity, BW25Activity],
     method: tuple,
     cutoff: float = 0.0001,
     filepath: str = None,
@@ -35,7 +45,7 @@ def treemap(
 
     assert isinstance(method, tuple), "`method` should be a tuple."
     assert isinstance(
-        activity, bw2data.backends.peewee.proxies.Activity
+        activity, Union[PeeweeActivity, BW25Activity]
     ), "`activity` should be a brightway2 activity."
 
     # fetch unit of method

--- a/polyviz/utils.py
+++ b/polyviz/utils.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from io import StringIO
 from pathlib import Path
 from packaging.version import Version
+from typing import Union
 
 import bw2calc
 import bw2data
@@ -13,9 +14,19 @@ import numpy as np
 import pandas as pd
 import yaml
 
+try:
+    from bw2data.backends.peewee import Activity as PeeweeActivity
+except ImportError:
+    PeeweeActivity = None
+
+try:
+    from bw2data.backends import Activity as BW25Activity
+except ImportError:
+    BW25Activity = None
+
 
 def calculate_supply_chain(
-    activity: bw2data.backends.peewee.proxies.Activity,
+    activity: Union[PeeweeActivity, BW25Activity],
     method: tuple,
     level: int = 3,
     cutoff: float = 0.01,
@@ -30,7 +41,7 @@ def calculate_supply_chain(
     """
 
     assert isinstance(
-        activity, bw2data.backends.peewee.proxies.Activity
+        activity, Union[PeeweeActivity, BW25Activity]
     ), "`activity` should be a brightway2 activity."
 
     amount = -1 if identify_waste_process(activity) else 1
@@ -55,7 +66,7 @@ def calculate_supply_chain(
 
 
 def calculate_lcia_score(
-    activity: bw2data.backends.peewee.proxies.Activity,
+    activity: Union[PeeweeActivity, BW25Activity],
     method: tuple,
 ) -> float:
     """
@@ -65,7 +76,7 @@ def calculate_lcia_score(
     :return: LCIA score, C matrix, and reverse dictionary
     """
     assert isinstance(
-        activity, bw2data.backends.peewee.proxies.Activity
+        activity, Union[PeeweeActivity, BW25Activity]
     ), "`activity` should be a brightway2 activity."
 
     print("Calculating LCIA score...")
@@ -92,7 +103,7 @@ def make_name_safe(filename: str) -> str:
     ).rstrip()
 
 
-def identify_waste_process(activity: bw2data.backends.peewee.proxies.Activity) -> bool:
+def identify_waste_process(activity: Union[PeeweeActivity, BW25Activity]) -> bool:
     """
     Identify if a process is a waste process.
     :param activity: a brightway2 activity
@@ -106,7 +117,7 @@ def identify_waste_process(activity: bw2data.backends.peewee.proxies.Activity) -
 
 
 def get_geo_distribution_of_impacts_for_choro_graph(
-    activity: bw2data.backends.peewee.proxies.Activity,
+    activity: Union[PeeweeActivity, BW25Activity],
     method: tuple,
     cutoff: float = 0.0001,
 ) -> pd.DataFrame:

--- a/polyviz/utils.py
+++ b/polyviz/utils.py
@@ -5,6 +5,7 @@ Utility functions for polyviz.
 from collections import defaultdict
 from io import StringIO
 from pathlib import Path
+from packaging.version import Version
 
 import bw2calc
 import bw2data
@@ -224,6 +225,15 @@ def recursive_calculation(
     elif total_score == 0:
         return results
     else:
+        bw2calc_version = (
+            ".".join(map(str, bw2calc.__version__))
+            if isinstance(bw2calc.__version__, tuple)
+            else bw2calc.__version__
+        )
+        if Version(bw2calc_version) >= Version("2.0.DEV1") and not getattr(
+            lca_obj, "_remapped", False
+        ):
+            lca_obj.remap_inventory_dicts()
         lca_obj.redo_lcia({activity: amount})
         if abs(lca_obj.score) <= abs(total_score * cutoff):
             results.append(

--- a/polyviz/violin.py
+++ b/polyviz/violin.py
@@ -6,9 +6,19 @@ import bw2data
 import pandas as pd
 from bw2calc.monte_carlo import MultiMonteCarlo
 from d3blocks import D3Blocks
+from typing import Union
 
 from .utils import check_filepath
 
+try:
+    from bw2data.backends.peewee import Activity as PeeweeActivity
+except ImportError:
+    PeeweeActivity = None
+
+try: 
+    from bw2data.backends import Activity as BW25Activity
+except ImportError:
+    BW25Activity = None
 
 def violin(
     activities: list,
@@ -33,7 +43,7 @@ def violin(
 
     for act in activities:
         assert isinstance(
-            act, bw2data.backends.peewee.proxies.Activity
+            act, Union[PeeweeActivity, BW25Activity]
         ), "`activity` should be a brightway2 activity."
 
     def make_name(activities):


### PR DESCRIPTION
When using polyviz with bw25, two problems occurred:

1. The type checks for the activities failed, as in bw25, activities are not of type bw2data.backends.peewee.Activity anymore, but bw2data.backends.Activity. I generalised this to check if the provided activity is one of both in 837f2077be4e0647f3e362bca376a7a50caaa85b.
2. In the recursive calculations, calling redo_lcia() caused an error. Unlike bw2, bw25 does not automatically remap the inventory dicts back from integer ids to (xx, yy) keys. I am not sure if there is a better solution from bw25-side, but simply calling bw25's remap_inventory_dicts() resolved the issue 837f2077be4e0647f3e362bca376a7a50caaa85b.

I am sure there are more elegant solutions for both problems, I'm sorry if I overlooked something obvious. Nevertheless, I thought I'd share this because, at least for me, polyviz is now working with both bw2 and bw25.